### PR TITLE
(fix) cross platform screen size

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,12 +8,9 @@ import 'settings/about_screen.dart';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:window_size/window_size.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  setWindowMinSize(const Size(800, 480));
-  setWindowMaxSize(const Size(800, 480));
   runApp(const Orion());
 }
 
@@ -77,8 +74,6 @@ class Orion extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 800,
-      height: 480,
       child: MaterialApp.router(
         debugShowCheckedModeBanner: false,
         routerConfig: _router,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,16 +43,16 @@ dependencies:
   path_provider: ^2.1.0
   qr_flutter: ^4.0.0
   wifi_info_flutter: ^2.0.2
-  window_size:
-    git:
-      url: https://github.com/google/flutter-desktop-embedding.git
-      path: plugins/window_size
+  # window_size:
+  #   git:
+  #     url: https://github.com/google/flutter-desktop-embedding.git
+  #     path: plugins/window_size
   flutter_svg: ^1.1.6
   archive: ^3.4.2
   permission_handler: ^11.0.1
   ini: ^2.1.0
   crypto: ^3.0.2
-  intl: ^0.17.0
+  intl: ^0.18.0
   wifi_flutter: ^0.2.0
 
 dev_dependencies:


### PR DESCRIPTION
Using the package window size gives problems when using other os to develop. the screen size must be done on your emulator not on the code itself. updated packages file