### PR TITLE
github_workflows: Redo tar process to remove redundant paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,12 @@ jobs:
 
       - name: Build, Copy, and Compress armv7
         run: |
+          BUILD_NAME=orion_armv7
+          mkdir $BUILD_NAME
           flutterpi_tool build --release
-          mv build/flutter_assets orion_armv7
-          tar -czvf orion_armv7.tar.gz orion_armv7
+          mv build/flutter_assets $BUILD_NAME
+          ( cd $BUILD_NAME && tar -czvf $BUILD_NAME.tar.gz * )
+          cp $BUILD_NAME/$BUILD_NAME.tar.gz $BUILD_NAME.tar.gz
 
       - uses: actions/upload-artifact@v4.3.1
         with:
@@ -37,9 +40,12 @@ jobs:
 
       - name: Build, Copy, and Compress aarch64
         run: |
+          BUILD_NAME=orion_aarch64
+          mkdir $BUILD_NAME
           flutterpi_tool build --arch=arm64 --release
-          mv build/flutter_assets orion_aarch64
-          tar -czvf orion_aarch64.tar.gz orion_aarch64
+          mv build/flutter_assets $BUILD_NAME
+          ( cd $BUILD_NAME && tar -czvf $BUILD_NAME.tar.gz * )
+          cp $BUILD_NAME/$BUILD_NAME.tar.gz $BUILD_NAME.tar.gz
 
       - uses: actions/upload-artifact@v4.3.1
         with:
@@ -48,9 +54,12 @@ jobs:
 
       - name: Build, Copy, and Compress x64
         run: |
+          BUILD_NAME=orion_x64
+          mkdir $BUILD_NAME
           flutterpi_tool build --arch=x64 --release
-          mv build/flutter_assets orion_x64
-          tar -czvf orion_x64.tar.gz orion_x64
+          mv build/flutter_assets $BUILD_NAME
+          ( cd $BUILD_NAME && tar -czvf $BUILD_NAME.tar.gz * )
+          cp $BUILD_NAME/$BUILD_NAME.tar.gz $BUILD_NAME.tar.gz
 
       - uses: actions/upload-artifact@v4.3.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Build, Copy, and Compress armv7
         run: |
           BUILD_NAME=orion_armv7
-          mkdir $BUILD_NAME
           flutterpi_tool build --release
           mv build/flutter_assets $BUILD_NAME
           ( cd $BUILD_NAME && tar -czvf $BUILD_NAME.tar.gz * )
@@ -41,7 +40,6 @@ jobs:
       - name: Build, Copy, and Compress aarch64
         run: |
           BUILD_NAME=orion_aarch64
-          mkdir $BUILD_NAME
           flutterpi_tool build --arch=arm64 --release
           mv build/flutter_assets $BUILD_NAME
           ( cd $BUILD_NAME && tar -czvf $BUILD_NAME.tar.gz * )
@@ -55,7 +53,6 @@ jobs:
       - name: Build, Copy, and Compress x64
         run: |
           BUILD_NAME=orion_x64
-          mkdir $BUILD_NAME
           flutterpi_tool build --arch=x64 --release
           mv build/flutter_assets $BUILD_NAME
           ( cd $BUILD_NAME && tar -czvf $BUILD_NAME.tar.gz * )


### PR DESCRIPTION
Re-implement build compression to avoid carrying toplevel dir into tar file