### PR TITLE
chore(gha): cache dependencies in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,12 @@ jobs:
         with:
           channel: "stable" # or: 'beta', 'dev', 'master' (or 'main')
           flutter-version: ${{ steps.flutterpi_engine.outputs.latest }}
+          cache: true
 
-      - run: sudo apt-get update && sudo apt-get install -y gtk+-3.0
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: gtk+-3.0
+
       - run: flutter pub global activate flutterpi_tool
 
       # Add these steps to verify and fix localization files


### PR DESCRIPTION
Add dependency caching for github action build workflow

First build
<img width="325" height="68" alt="image" src="https://github.com/user-attachments/assets/5413958d-1526-4c16-a96b-30bdfba344ea" />

Second
<img width="325" height="73" alt="image" src="https://github.com/user-attachments/assets/0fa78efc-e576-43a1-97a4-8205f4d645ff" />
