### PR TITLE
feat: NanoDLP: USB File imports

### DIFF
--- a/lib/backend_service/backend_service.dart
+++ b/lib/backend_service/backend_service.dart
@@ -20,6 +20,7 @@ import 'package:orion/backend_service/backend_client.dart';
 import 'package:orion/backend_service/odyssey/odyssey_http_client.dart';
 import 'package:orion/backend_service/nanodlp/nanodlp_http_client.dart';
 import 'package:orion/backend_service/nanodlp/helpers/nano_simulated_client.dart';
+import 'package:orion/backend_service/nanodlp/models/nano_import_request.dart';
 import 'package:orion/util/orion_config.dart';
 
 /// BackendService is a small façade that selects a concrete
@@ -99,6 +100,15 @@ class BackendService implements BackendClient {
   @override
   Future<bool> usbAvailable() => _delegate.usbAvailable();
 
+  /// Invalidate cached file listings (NanoDLP plates cache).
+  /// Call this when files may have been modified externally (e.g., deleted via WebUI).
+  void invalidateFilesCache() {
+    if (_delegate is NanoDlpHttpClient) {
+      (_delegate as NanoDlpHttpClient).invalidatePlatesCache();
+    }
+    // Other backends don't cache, so no action needed
+  }
+
   @override
   Future<Map<String, dynamic>> getFileMetadata(
           String location, String filePath) =>
@@ -122,6 +132,20 @@ class BackendService implements BackendClient {
   @override
   Future<Map<String, dynamic>> deleteFile(String location, String filePath) =>
       _delegate.deleteFile(location, filePath);
+
+  /// Import a file from USB/local storage to NanoDLP's internal storage.
+  ///
+  /// This is a NanoDLP-specific feature. If the current backend is not NanoDLP,
+  /// this will throw an UnsupportedError.
+  ///
+  /// Returns the plate ID if successful, null if ID couldn't be determined.
+  Future<int?> importFile(NanoImportRequest request) async {
+    if (_delegate is NanoDlpHttpClient) {
+      return (_delegate as NanoDlpHttpClient).importFile(request);
+    }
+    throw UnsupportedError(
+        'File import is only supported with NanoDLP backend');
+  }
 
   @override
   Future<Map<String, dynamic>> getStatus() => _delegate.getStatus();

--- a/lib/backend_service/nanodlp/models/nano_import_request.dart
+++ b/lib/backend_service/nanodlp/models/nano_import_request.dart
@@ -1,0 +1,101 @@
+/*
+* Orion - NanoDLP Import Request Model
+* Copyright (C) 2025 Open Resin Alliance
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/// Model for NanoDLP file import request parameters.
+///
+/// Represents the data needed to import a file from USB/local storage
+/// to NanoDLP's internal storage with associated settings.
+class NanoImportRequest {
+  /// Full path to the USB/local file to import
+  final String usbFilePath;
+
+  /// Job/plate name to save the file as in NanoDLP
+  final String jobName;
+
+  /// Material profile ID to associate with this print
+  final String profileId;
+
+  /// Optional path to a zip file (typically empty)
+  final String? zipFile;
+
+  /// Auto-center the model (0 = disabled, 1 = enabled)
+  final int autoCenter;
+
+  /// Multi-thickness settings (comma-separated values or empty)
+  final String? multiThickness;
+
+  /// Multi-cure settings (comma-separated values or empty)
+  final String? multiCure;
+
+  /// Z-offset in mm
+  final double offset;
+
+  /// Stop at specific layers (comma-separated layer numbers or empty)
+  final String? stopLayers;
+
+  /// Number of low quality layers
+  final int lowQualityLayerNumber;
+
+  /// Path to mask file (typically empty)
+  final String? maskFile;
+
+  /// Mask effect strength (0.00 - 1.00)
+  final double maskEffect;
+
+  /// Image rotation in degrees (0, 90, 180, 270)
+  final int imageRotate;
+
+  const NanoImportRequest({
+    required this.usbFilePath,
+    required this.jobName,
+    required this.profileId,
+    this.zipFile = '',
+    this.autoCenter = 0,
+    this.multiThickness = '',
+    this.multiCure = '',
+    this.offset = 0.0,
+    this.stopLayers = '',
+    this.lowQualityLayerNumber = 0,
+    this.maskFile = '',
+    this.maskEffect = 0.0,
+    this.imageRotate = 0,
+  });
+
+  /// Convert to multipart form fields for NanoDLP's /importfile endpoint
+  Map<String, String> toFormFields() {
+    return {
+      'USBFile': usbFilePath,
+      'ZipFile': zipFile ?? '',
+      'Path': jobName,
+      'ProfileID': profileId,
+      'AutoCenter': autoCenter.toString(),
+      'MultiThickness': multiThickness ?? '',
+      'MultiCure': multiCure ?? '',
+      'Offset': offset.toStringAsFixed(2),
+      'StopLayers': stopLayers ?? '',
+      'LowQualityLayerNumber': lowQualityLayerNumber.toString(),
+      'MaskFile': maskFile ?? '',
+      'MaskEffect': maskEffect.toStringAsFixed(2),
+      'ImageRotate': imageRotate.toString(),
+    };
+  }
+
+  @override
+  String toString() {
+    return 'NanoImportRequest(usbFile: $usbFilePath, jobName: $jobName, profileId: $profileId)';
+  }
+}

--- a/lib/backend_service/providers/files_provider.dart
+++ b/lib/backend_service/providers/files_provider.dart
@@ -45,11 +45,26 @@ class FilesProvider extends ChangeNotifier {
 
   FilesProvider({BackendClient? client}) : _client = client ?? BackendService();
 
+  /// Invalidate backend file cache (NanoDLP plates cache) if supported.
+  void invalidateFilesCache() {
+    final client = _client;
+    if (client is BackendService) {
+      client.invalidateFilesCache();
+    }
+  }
+
   /// Load items into provider state (convenience wrapper around listItemsAsOrionApiItems)
   Future<void> loadItems(String location, String subdirectory,
       {int pageSize = 100, int pageIndex = 0}) async {
     _log.info(
         'loadItems: location=$location subdirectory=$subdirectory pageSize=$pageSize pageIndex=$pageIndex');
+    
+    // Invalidate backend cache to ensure fresh data (important after external changes)
+    final client = _client;
+    if (client is BackendService) {
+      client.invalidateFilesCache();
+    }
+    
     _loading = true;
     _error = null;
     notifyListeners();

--- a/lib/backend_service/providers/local_files_provider.dart
+++ b/lib/backend_service/providers/local_files_provider.dart
@@ -1,0 +1,302 @@
+/*
+ * Orion - Local Files Provider
+ * Copyright (C) 2025 Open Resin Alliance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'package:orion/util/orion_api_filesystem/orion_api_file.dart';
+import 'package:orion/util/orion_api_filesystem/orion_api_directory.dart';
+import 'package:orion/util/orion_api_filesystem/orion_api_item.dart';
+
+/// Provides file listing from local filesystem for USB/Media directories
+/// 
+/// Used on NanoDLP machines when there is no backend override URL.
+/// On Linux, scans /media/usb for .stl and .nanodlp files.
+/// On macOS (development), scans ~/Documents for testing.
+class LocalFilesProvider extends ChangeNotifier {
+  final _log = Logger('LocalFilesProvider');
+
+  // Base directory to scan for files
+  late final String _baseDirectory;
+
+  List<OrionApiItem> _items = [];
+  List<OrionApiItem> get items => _items;
+
+  bool _loading = false;
+  bool get isLoading => _loading;
+
+  Object? _error;
+  Object? get error => _error;
+
+  String _location = 'Local';
+  String get location => _location;
+
+  String _subdirectory = '';
+  String get subdirectory => _subdirectory;
+
+  // Expose base directory for testing and initialization
+  String get baseDirectory => _baseDirectory;
+
+  // Supported file extensions
+  static const List<String> supportedExtensions = ['.stl', '.nanodlp'];
+
+  LocalFilesProvider({String? baseDirectory}) {
+    if (baseDirectory != null) {
+      _baseDirectory = baseDirectory;
+    } else {
+      // Platform-specific defaults: macOS uses ~/Documents for development, Linux uses /media/usb
+      if (Platform.isMacOS) {
+        final username = Platform.environment['USER'];
+        _baseDirectory = username != null ? '/Users/$username/Documents' : '~/Documents';
+      } else {
+        _baseDirectory = '/media/usb';
+      }
+    }
+  }
+
+  /// Load items from the filesystem
+  Future<void> loadItems(String location, String subdirectory,
+      {int pageSize = 100, int pageIndex = 0}) async {
+    _log.info(
+        'loadItems: location=$location subdirectory=$subdirectory pageSize=$pageSize pageIndex=$pageIndex');
+    _loading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      // Build the full path to scan
+      final fullPath = subdirectory.isEmpty
+          ? _baseDirectory
+          : path.join(_baseDirectory, subdirectory);
+
+      // Resolve the path to prevent directory traversal attacks (../..)
+      final resolvedPath = path.normalize(path.absolute(fullPath));
+      final resolvedBase = path.normalize(path.absolute(_baseDirectory));
+
+      // Validate that the resolved path is within the base directory
+      if (!resolvedPath.startsWith(resolvedBase)) {
+        _log.warning(
+            'Attempted to navigate outside base directory. Base: $resolvedBase, Requested: $resolvedPath');
+        // Cap at base directory if trying to escape
+        _items = [];
+        _location = location;
+        _subdirectory = ''; // Reset to base
+        _loading = false;
+        _error = null;
+        notifyListeners();
+        return;
+      }
+
+      final dir = Directory(resolvedPath);
+
+      // Check if directory exists
+      if (!dir.existsSync()) {
+        _log.warning('Directory does not exist: $resolvedPath');
+        _items = [];
+        _location = location;
+        _subdirectory = '';
+        _loading = false;
+        _error = null;
+        notifyListeners();
+        return;
+      }
+
+      // List all items in the directory
+      final List<OrionApiItem> items = [];
+
+      // Add directories first
+      final dirEntities = dir.listSync(recursive: false, followLinks: false);
+      final directories = <OrionApiDirectory>[];
+      final files = <OrionApiFile>[];
+
+      for (final entity in dirEntities) {
+        if (entity is Directory) {
+          try {
+            directories.add(_createDirectoryItem(entity, resolvedPath));
+          } catch (e) {
+            _log.warning('Failed to create directory item: ${entity.path}', e);
+          }
+        } else if (entity is File) {
+          if (_isSupportedFile(entity.path)) {
+            try {
+              files.add(_createFileItem(entity, resolvedPath));
+            } catch (e) {
+              _log.warning('Failed to create file item: ${entity.path}', e);
+            }
+          }
+        }
+      }
+
+      // Sort items
+      directories.sort((a, b) => a.name.compareTo(b.name));
+      files.sort((a, b) => a.name.compareTo(b.name));
+
+      items.addAll(directories);
+      items.addAll(files);
+
+      _items = items;
+      _location = location;
+      // Store relative path from base directory
+      _subdirectory = resolvedPath == resolvedBase
+          ? ''
+          : path.relative(resolvedPath, from: resolvedBase);
+      _loading = false;
+      _error = null;
+      _log.fine(
+          'loadItems: loaded ${_items.length} items from $resolvedPath (${directories.length} dirs, ${files.length} files)');
+    } catch (e, st) {
+      _log.severe('Failed to load items from filesystem', e, st);
+      _error = e;
+      _loading = false;
+      _items = [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  /// Check if a file is supported (has supported extension)
+  bool _isSupportedFile(String filePath) {
+    final ext = path.extension(filePath).toLowerCase();
+    return supportedExtensions.contains(ext);
+  }
+
+  /// Create an OrionApiDirectory from a File entity
+  OrionApiDirectory _createDirectoryItem(Directory dir, String parentPath) {
+    final stat = dir.statSync();
+    final name = path.basename(dir.path);
+    return OrionApiDirectory(
+      path: dir.path,
+      name: name,
+      lastModified: stat.modified.millisecondsSinceEpoch,
+      locationCategory: 'Local',
+      parentPath: parentPath,
+    );
+  }
+
+  /// Create an OrionApiFile from a File entity
+  OrionApiFile _createFileItem(File file, String parentPath) {
+    final stat = file.statSync();
+    final name = path.basename(file.path);
+    return OrionApiFile(
+      file: file,
+      path: file.path,
+      name: name,
+      parentPath: parentPath,
+      lastModified: stat.modified.millisecondsSinceEpoch,
+      locationCategory: 'Local',
+    );
+  }
+
+  /// Check if USB/media directory is available
+  Future<bool> usbAvailable() async {
+    try {
+      final dir = Directory(_baseDirectory);
+      return dir.existsSync();
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Delete a file (not implemented for local provider - would need special permissions)
+  Future<bool> deleteFile(String location, String filePath) async {
+    _log.warning('deleteFile not supported for LocalFilesProvider');
+    return false;
+  }
+
+  /// Start print (not implemented for local provider - would need backend integration)
+  Future<bool> startPrint(String location, String filePath) async {
+    _log.warning('startPrint not supported for LocalFilesProvider');
+    return false;
+  }
+
+  /// List items as OrionApiItems
+  Future<List<OrionApiItem>> listItemsAsOrionApiItems(
+      String location, String subdirectory,
+      {int pageSize = 100, int pageIndex = 0}) async {
+    _log.info(
+        'listItemsAsOrionApiItems: location=$location subdirectory=$subdirectory pageSize=$pageSize pageIndex=$pageIndex');
+    try {
+      // Build the full path to scan
+      final fullPath = subdirectory.isEmpty
+          ? _baseDirectory
+          : path.join(_baseDirectory, subdirectory);
+
+      // Resolve the path to prevent directory traversal attacks (../..)
+      final resolvedPath = path.normalize(path.absolute(fullPath));
+      final resolvedBase = path.normalize(path.absolute(_baseDirectory));
+
+      // Validate that the resolved path is within the base directory
+      if (!resolvedPath.startsWith(resolvedBase)) {
+        _log.warning(
+            'Attempted to navigate outside base directory in listItems. Base: $resolvedBase, Requested: $resolvedPath');
+        return [];
+      }
+
+      final dir = Directory(resolvedPath);
+
+      // Check if directory exists
+      if (!dir.existsSync()) {
+        _log.warning('Directory does not exist: $resolvedPath');
+        return [];
+      }
+
+      // List all items in the directory
+      final List<OrionApiItem> items = [];
+
+      // Add directories first
+      final dirEntities = dir.listSync(recursive: false, followLinks: false);
+      final directories = <OrionApiDirectory>[];
+      final files = <OrionApiFile>[];
+
+      for (final entity in dirEntities) {
+        if (entity is Directory) {
+          try {
+            directories.add(_createDirectoryItem(entity, resolvedPath));
+          } catch (e) {
+            _log.warning('Failed to create directory item: ${entity.path}', e);
+          }
+        } else if (entity is File) {
+          if (_isSupportedFile(entity.path)) {
+            try {
+              files.add(_createFileItem(entity, resolvedPath));
+            } catch (e) {
+              _log.warning('Failed to create file item: ${entity.path}', e);
+            }
+          }
+        }
+      }
+
+      // Sort items
+      directories.sort((a, b) => a.name.compareTo(b.name));
+      files.sort((a, b) => a.name.compareTo(b.name));
+
+      items.addAll(directories);
+      items.addAll(files);
+
+      _log.fine(
+          'listItemsAsOrionApiItems: built items count=${items.length}');
+      return items;
+    } catch (e, st) {
+      _log.severe('Failed to fetch items as OrionApiItems', e, st);
+      rethrow;
+    }
+  }
+}

--- a/lib/files/details_screen.dart
+++ b/lib/files/details_screen.dart
@@ -225,69 +225,71 @@ class DetailScreenState extends State<DetailScreen> {
             title: const Text('Back'),
             // Move the filename + date into the visual center of the AppBar.
             centerWidget: Builder(builder: (context) {
-            // Use a single base font size for both title lines so they appear
-            // visually consistent. If the AppBar theme provides a title
-            // fontSize, use that as the base; otherwise default to 14 and
-            // reduce slightly.
-            final baseFontSize =
-                (Theme.of(context).appBarTheme.titleTextStyle?.fontSize ?? 14) -
-                    10;
+              // Use a single base font size for both title lines so they appear
+              // visually consistent. If the AppBar theme provides a title
+              // fontSize, use that as the base; otherwise default to 14 and
+              // reduce slightly.
+              final baseFontSize =
+                  (Theme.of(context).appBarTheme.titleTextStyle?.fontSize ??
+                          14) -
+                      10;
 
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  widget.fileName.isNotEmpty ? widget.fileName : 'No file',
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).appBarTheme.titleTextStyle?.copyWith(
-                        fontSize: baseFontSize,
-                        fontWeight: FontWeight.normal,
-                        color: Theme.of(context)
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    widget.fileName.isNotEmpty ? widget.fileName : 'No file',
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style:
+                        Theme.of(context).appBarTheme.titleTextStyle?.copyWith(
+                              fontSize: baseFontSize,
+                              fontWeight: FontWeight.normal,
+                              color: Theme.of(context)
+                                  .appBarTheme
+                                  .titleTextStyle
+                                  ?.color
+                                  ?.withValues(alpha: 0.95),
+                            ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    // Show the material name (if present) with any leading
+                    // bracketed prefixes stripped (e.g. "[AFP] Resin" -> "Resin").
+                    _stripMaterialPrefix(_meta?.materialName),
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context)
                             .appBarTheme
                             .titleTextStyle
-                            ?.color
-                            ?.withValues(alpha: 0.95),
-                      ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  // Show the material name (if present) with any leading
-                  // bracketed prefixes stripped (e.g. "[AFP] Resin" -> "Resin").
-                  _stripMaterialPrefix(_meta?.materialName),
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context)
-                          .appBarTheme
-                          .titleTextStyle
-                          ?.merge(TextStyle(
-                            fontWeight: FontWeight.normal,
-                            fontSize: baseFontSize,
-                          ))
-                          .copyWith(
-                            // Make status less visually dominant by lowering
-                            // its alpha relative to the AppBar title color.
-                            color: Theme.of(context)
-                                .appBarTheme
-                                .titleTextStyle
-                                ?.color
-                                ?.withValues(alpha: 0.65),
-                          ) ??
-                      TextStyle(
-                        fontSize: baseFontSize,
-                        fontWeight: FontWeight.normal,
-                        color: Theme.of(context)
-                            .appBarTheme
-                            .titleTextStyle
-                            ?.color
-                            ?.withValues(alpha: 0.65),
-                      ),
-                ),
-              ],
-            );
+                            ?.merge(TextStyle(
+                              fontWeight: FontWeight.normal,
+                              fontSize: baseFontSize,
+                            ))
+                            .copyWith(
+                              // Make status less visually dominant by lowering
+                              // its alpha relative to the AppBar title color.
+                              color: Theme.of(context)
+                                  .appBarTheme
+                                  .titleTextStyle
+                                  ?.color
+                                  ?.withValues(alpha: 0.65),
+                            ) ??
+                        TextStyle(
+                          fontSize: baseFontSize,
+                          fontWeight: FontWeight.normal,
+                          color: Theme.of(context)
+                              .appBarTheme
+                              .titleTextStyle
+                              ?.color
+                              ?.withValues(alpha: 0.65),
+                        ),
+                  ),
+                ],
+              );
             }),
           ),
           body: Center(
@@ -555,16 +557,75 @@ class DetailScreenState extends State<DetailScreen> {
       context: context,
       builder: (BuildContext context) {
         return GlassAlertDialog(
-          title: const Text('Delete File'),
-          content: const Text(
-            'Are you sure you want to delete this file?\nThis action cannot be undone.',
+          title: Row(
+            children: [
+              Icon(
+                Icons.delete_forever_rounded,
+                color: Theme.of(context).colorScheme.error,
+                size: 26,
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Delete File',
+                      style: TextStyle(
+                        fontSize: 22,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      widget.fileName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: Colors.grey.shade400,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const [
+              Text(
+                'Are you sure you want to delete this file?',
+                style: TextStyle(
+                  fontSize: 18,
+                  height: 1.5,
+                ),
+              ),
+              SizedBox(height: 8),
+              Text(
+                'This action cannot be undone.',
+                style: TextStyle(
+                  fontSize: 18,
+                  height: 1.5,
+                ),
+              ),
+            ],
           ),
           actions: [
             GlassButton(
+              tint: GlassButtonTint.neutral,
+              style: ElevatedButton.styleFrom(
+                minimumSize: const Size(0, 60),
+              ),
               onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('Cancel', style: TextStyle(fontSize: 20)),
+              child: const Text('Cancel', style: TextStyle(fontSize: 22)),
             ),
             GlassButton(
+              tint: GlassButtonTint.negative,
+              style: ElevatedButton.styleFrom(
+                minimumSize: const Size(0, 60),
+              ),
               onPressed: () async {
                 try {
                   final provider =
@@ -588,7 +649,7 @@ class DetailScreenState extends State<DetailScreen> {
                   if (mounted) Navigator.of(context).pop(false);
                 }
               },
-              child: const Text('Delete', style: TextStyle(fontSize: 20)),
+              child: const Text('Delete', style: TextStyle(fontSize: 22)),
             ),
           ],
         );

--- a/lib/files/import_progress_overlay.dart
+++ b/lib/files/import_progress_overlay.dart
@@ -1,0 +1,231 @@
+/*
+* Orion - Import Progress Overlay
+* Copyright (C) 2025 Open Resin Alliance
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:provider/provider.dart';
+
+import 'package:orion/glasser/glasser.dart';
+import 'package:orion/util/providers/theme_provider.dart';
+
+/// A full-screen modal overlay that displays import progress and messages.
+/// Designed to be shown during file import to inform the user of progress.
+class ImportProgressOverlay extends StatefulWidget {
+  final ValueListenable<double> progress;
+  final ValueListenable<String> message;
+  final IconData icon;
+  final ValueListenable<IconData>? iconListenable;
+  final ValueListenable<String>? title;
+
+  const ImportProgressOverlay({
+    super.key,
+    required this.progress,
+    required this.message,
+    this.icon = PhosphorIconsFill.upload,
+    this.iconListenable,
+    this.title,
+  });
+
+  @override
+  State<ImportProgressOverlay> createState() => _ImportProgressOverlayState();
+}
+
+class _ImportProgressOverlayState extends State<ImportProgressOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulseController;
+  late final Animation<double> _pulseAnim;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    )..repeat(reverse: true);
+    _pulseAnim = Tween<double>(begin: 0.99, end: 1.03).animate(
+      CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isGlass =
+        Provider.of<ThemeProvider>(context, listen: false).isGlassTheme;
+
+    return GlassApp(
+      child: Scaffold(
+        backgroundColor: isGlass
+            ? Colors.transparent
+            : Theme.of(context).colorScheme.surface,
+        body: SafeArea(
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              // Centered icon with pulsing animation
+              Center(
+                child: Transform.translate(
+                  offset: const Offset(0, -30),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      // Pulsing icon
+                      ScaleTransition(
+                        scale: _pulseAnim,
+                        child: Padding(
+                          padding: const EdgeInsets.all(8),
+                          child: widget.iconListenable == null
+                              ? Icon(
+                                  widget.icon,
+                                  size: 120,
+                                  color: Theme.of(context).colorScheme.primary,
+                                )
+                              : ValueListenableBuilder<IconData>(
+                                  valueListenable: widget.iconListenable!,
+                                  builder: (context, icon, _) => Icon(
+                                    icon,
+                                    size: 120,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .primary,
+                                  ),
+                                ),
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+                      widget.title == null
+                          ? Text(
+                              'IMPORTING FILE',
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                fontSize: 30,
+                                color: Theme.of(context).colorScheme.primary,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            )
+                          : ValueListenableBuilder<String>(
+                              valueListenable: widget.title!,
+                              builder: (context, title, _) => Text(
+                                title,
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  fontSize: 30,
+                                  color:
+                                      Theme.of(context).colorScheme.primary,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                      const SizedBox(height: 5),
+                      widget.title == null
+                          ? Text(
+                              'Please wait while your file is being imported.',
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                fontSize: 24,
+                                color:
+                                    Theme.of(context).colorScheme.secondary,
+                              ),
+                            )
+                          : ValueListenableBuilder<String>(
+                              valueListenable: widget.title!,
+                              builder: (context, title, _) => Text(
+                                title == 'SLICING JOB'
+                                    ? 'Please wait while your job is being sliced.'
+                                    : 'Please wait while your file is being imported.',
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  fontSize: 24,
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .secondary,
+                                ),
+                              ),
+                            ),
+                      const SizedBox(height: 32),
+                    ],
+                  ),
+                ),
+              ),
+
+              // Bottom message
+              Positioned(
+                left: 20,
+                right: 20,
+                bottom: 30,
+                child: ValueListenableBuilder<String>(
+                  valueListenable: widget.message,
+                  builder: (context, msg, _) => Text(
+                    msg,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontFamily: 'AtkinsonHyperlegible',
+                      fontSize: 24,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                ),
+              ),
+
+              // Progress bar positioned above the message (smoothly animated)
+              Positioned(
+                left: 40,
+                right: 40,
+                bottom: 90,
+                child: ValueListenableBuilder<double>(
+                  valueListenable: widget.progress,
+                  builder: (context, p, _) => SizedBox(
+                    height: 14,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(7),
+                      child: p < 0
+                          ? LinearProgressIndicator(
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                  Theme.of(context).colorScheme.primary),
+                              backgroundColor:
+                                  Colors.black.withValues(alpha: 0.3),
+                            )
+                          : TweenAnimationBuilder<double>(
+                              tween: Tween<double>(end: p.clamp(0.0, 1.0)),
+                              duration: const Duration(milliseconds: 600),
+                              curve: Curves.easeInOut,
+                              builder: (context, animatedP, _) =>
+                                  LinearProgressIndicator(
+                                value: animatedP,
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                    Theme.of(context).colorScheme.primary),
+                                backgroundColor:
+                                    Colors.black.withValues(alpha: 0.3),
+                              ),
+                            ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/files/import_progress_overlay.dart
+++ b/lib/files/import_progress_overlay.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:provider/provider.dart';
+import 'dart:math' as math;
 
 import 'package:orion/glasser/glasser.dart';
 import 'package:orion/util/providers/theme_provider.dart';
@@ -36,7 +37,7 @@ class ImportProgressOverlay extends StatefulWidget {
     super.key,
     required this.progress,
     required this.message,
-    this.icon = PhosphorIconsFill.upload,
+    this.icon = PhosphorIconsFill.package,
     this.iconListenable,
     this.title,
   });
@@ -46,9 +47,10 @@ class ImportProgressOverlay extends StatefulWidget {
 }
 
 class _ImportProgressOverlayState extends State<ImportProgressOverlay>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   late final AnimationController _pulseController;
   late final Animation<double> _pulseAnim;
+  late final AnimationController _sliceController;
 
   @override
   void initState() {
@@ -60,11 +62,17 @@ class _ImportProgressOverlayState extends State<ImportProgressOverlay>
     _pulseAnim = Tween<double>(begin: 0.99, end: 1.03).animate(
       CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
     );
+
+    _sliceController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2500),
+    )..repeat();
   }
 
   @override
   void dispose() {
     _pulseController.dispose();
+    _sliceController.dispose();
     super.dispose();
   }
 
@@ -89,26 +97,46 @@ class _ImportProgressOverlayState extends State<ImportProgressOverlay>
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      // Pulsing icon
+                      // Pulsing icon or animated slicing block
                       ScaleTransition(
                         scale: _pulseAnim,
                         child: Padding(
                           padding: const EdgeInsets.all(8),
-                          child: widget.iconListenable == null
-                              ? Icon(
-                                  widget.icon,
-                                  size: 120,
-                                  color: Theme.of(context).colorScheme.primary,
-                                )
-                              : ValueListenableBuilder<IconData>(
-                                  valueListenable: widget.iconListenable!,
-                                  builder: (context, icon, _) => Icon(
-                                    icon,
-                                    size: 120,
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .primary,
-                                  ),
+                          child: widget.title == null
+                              ? (widget.iconListenable == null
+                                  ? Icon(
+                                      widget.icon,
+                                      size: 120,
+                                      color:
+                                          Theme.of(context).colorScheme.primary,
+                                    )
+                                  : ValueListenableBuilder<IconData>(
+                                      valueListenable: widget.iconListenable!,
+                                      builder: (context, icon, _) => Icon(
+                                        icon,
+                                        size: 120,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .primary,
+                                      ),
+                                    ))
+                              : ValueListenableBuilder<String>(
+                                  valueListenable: widget.title!,
+                                  builder: (context, title, _) =>
+                                      title == 'SLICING JOB'
+                                          ? _AnimatedSlicingBlock(
+                                              controller: _sliceController,
+                                              primaryColor: Theme.of(context)
+                                                  .colorScheme
+                                                  .primary,
+                                            )
+                                          : Icon(
+                                              widget.icon,
+                                              size: 120,
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .primary,
+                                            ),
                                 ),
                         ),
                       ),
@@ -130,8 +158,7 @@ class _ImportProgressOverlayState extends State<ImportProgressOverlay>
                                 textAlign: TextAlign.center,
                                 style: TextStyle(
                                   fontSize: 30,
-                                  color:
-                                      Theme.of(context).colorScheme.primary,
+                                  color: Theme.of(context).colorScheme.primary,
                                   fontWeight: FontWeight.bold,
                                 ),
                               ),
@@ -143,8 +170,7 @@ class _ImportProgressOverlayState extends State<ImportProgressOverlay>
                               textAlign: TextAlign.center,
                               style: TextStyle(
                                 fontSize: 24,
-                                color:
-                                    Theme.of(context).colorScheme.secondary,
+                                color: Theme.of(context).colorScheme.secondary,
                               ),
                             )
                           : ValueListenableBuilder<String>(
@@ -156,13 +182,12 @@ class _ImportProgressOverlayState extends State<ImportProgressOverlay>
                                 textAlign: TextAlign.center,
                                 style: TextStyle(
                                   fontSize: 24,
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .secondary,
+                                  color:
+                                      Theme.of(context).colorScheme.secondary,
                                 ),
                               ),
                             ),
-                      const SizedBox(height: 32),
+                      const SizedBox(height: 18),
                     ],
                   ),
                 ),
@@ -227,5 +252,171 @@ class _ImportProgressOverlayState extends State<ImportProgressOverlay>
         ),
       ),
     );
+  }
+}
+
+/// Custom animated widget showing a cube being sliced horizontally.
+/// Used as the icon during slicing operations.
+class _AnimatedSlicingBlock extends StatelessWidget {
+  final AnimationController controller;
+  final Color primaryColor;
+
+  const _AnimatedSlicingBlock({
+    required this.controller,
+    required this.primaryColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 120,
+      height: 120,
+      child: AnimatedBuilder(
+        animation: controller,
+        builder: (context, _) {
+          final progress = controller.value;
+          // Smooth easing for slice count, with a pop-out separation
+          final countT = Curves.easeInOut.transform(progress);
+          final popT = Curves.easeOutBack.transform(progress);
+          final numSlices = (countT * 6).toInt() + 1;
+          final separation = popT * 18;
+
+          return CustomPaint(
+            painter: _CubeSlicePainter(
+              primaryColor: primaryColor,
+              sliceCount: numSlices,
+              separation: separation,
+            ),
+            size: const Size(120, 120),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CubeSlicePainter extends CustomPainter {
+  final Color primaryColor;
+  final int sliceCount;
+  final double separation;
+
+  _CubeSlicePainter({
+    required this.primaryColor,
+    required this.sliceCount,
+    required this.separation,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final outlineStroke = Paint()
+      ..color = primaryColor.withValues(alpha: 0.8)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    final centerX = size.width / 2;
+    final centerY = size.height / 2;
+
+    const double cubeSize = 85;
+    const double depth = 20;
+    const double cornerRadius = 4;
+
+    final baseRect = Rect.fromCenter(
+      center: Offset(centerX, centerY),
+      width: cubeSize,
+      height: cubeSize,
+    );
+
+    final sliceHeight = cubeSize / sliceCount;
+
+    // Draw slices from back to front for proper 3D occlusion
+    for (int i = 0; i < sliceCount; i++) {
+      // Calculate offset from center for peeling effect
+      final centerIndex = sliceCount / 2.0;
+      final distanceFromCenter = (i - centerIndex).abs();
+
+      // Add wavy motion with sine for peeling effect
+      final waveAmount =
+          math.sin((i / sliceCount) * math.pi) * separation * 0.3;
+      final sliceVerticalOffset =
+          distanceFromCenter * separation * (i < centerIndex ? -0.5 : 0.5);
+      final sliceHorizontalOffset = waveAmount;
+
+      final sliceTop = baseRect.top + (sliceHeight * i) + sliceVerticalOffset;
+      final sliceLeft = baseRect.left + sliceHorizontalOffset;
+
+      final sliceRect = Rect.fromLTWH(
+        sliceLeft,
+        sliceTop,
+        cubeSize,
+        sliceHeight - 1,
+      );
+
+      // Create gradient fill for bubbly gel effect
+      final gradientFill = Paint()
+        ..shader = LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            primaryColor.withValues(alpha: 0.25),
+            primaryColor.withValues(alpha: 0.1),
+          ],
+        ).createShader(sliceRect)
+        ..style = PaintingStyle.fill;
+
+      // Draw front face with rounded corners for bubble effect
+      final frontRRect =
+          RRect.fromRectAndRadius(sliceRect, Radius.circular(cornerRadius));
+      canvas.drawRRect(frontRRect, gradientFill);
+      canvas.drawRRect(frontRRect, outlineStroke);
+
+      // Draw 3D depth faces
+      final topRight = Offset(
+        sliceRect.right + depth / 3,
+        sliceRect.top - depth / 3,
+      );
+      final bottomRight = Offset(
+        sliceRect.right + depth / 3,
+        sliceRect.bottom - depth / 3,
+      );
+      final topLeft = Offset(
+        sliceRect.left + depth / 4,
+        sliceRect.top - depth / 4,
+      );
+
+      // Right face - slightly darker for depth
+      final rightFill = Paint()
+        ..color = primaryColor.withValues(alpha: 0.08)
+        ..style = PaintingStyle.fill;
+      final rightPath = Path()
+        ..moveTo(sliceRect.right, sliceRect.top)
+        ..lineTo(topRight.dx, topRight.dy)
+        ..lineTo(bottomRight.dx, bottomRight.dy)
+        ..lineTo(sliceRect.right, sliceRect.bottom)
+        ..close();
+      canvas.drawPath(rightPath, rightFill);
+      canvas.drawPath(rightPath, outlineStroke);
+
+      // Top face - lighter for gel bubble effect
+      final topFill = Paint()
+        ..color = primaryColor.withValues(alpha: 0.12)
+        ..style = PaintingStyle.fill;
+      final topPath = Path()
+        ..moveTo(sliceRect.left, sliceRect.top)
+        ..lineTo(topLeft.dx, topLeft.dy)
+        ..lineTo(topRight.dx, topRight.dy)
+        ..lineTo(sliceRect.right, sliceRect.top)
+        ..close();
+      canvas.drawPath(topPath, topFill);
+      canvas.drawPath(topPath, outlineStroke);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_CubeSlicePainter oldDelegate) {
+    return oldDelegate.sliceCount != sliceCount ||
+        oldDelegate.separation != separation ||
+        oldDelegate.primaryColor != primaryColor;
   }
 }

--- a/lib/files/import_screen.dart
+++ b/lib/files/import_screen.dart
@@ -1,0 +1,812 @@
+/*
+* Orion - Import Screen
+* Copyright (C) 2025 Open Resin Alliance
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import 'dart:io';
+
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import 'package:provider/provider.dart';
+import 'package:path/path.dart' as path;
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import 'package:orion/glasser/glasser.dart';
+import 'package:orion/util/widgets/system_status_widget.dart';
+import 'package:orion/widgets/orion_app_bar.dart';
+import 'package:orion/util/orion_kb/orion_textfield_spawn.dart';
+import 'package:orion/util/orion_kb/orion_keyboard_expander.dart';
+import 'package:orion/backend_service/providers/resins_provider.dart';
+import 'package:orion/backend_service/backend_service.dart';
+import 'package:orion/backend_service/nanodlp/models/nano_import_request.dart';
+import 'package:orion/backend_service/providers/files_provider.dart';
+import 'package:orion/backend_service/odyssey/models/files_models.dart';
+import 'package:orion/files/details_screen.dart';
+import 'package:orion/files/import_progress_overlay.dart';
+import 'package:orion/util/orion_api_filesystem/orion_api_file.dart';
+
+class ImportScreen extends StatefulWidget {
+  final String fileName;
+  final String filePath;
+
+  const ImportScreen({
+    super.key,
+    required this.fileName,
+    required this.filePath,
+  });
+
+  @override
+  ImportScreenState createState() => ImportScreenState();
+}
+
+class ImportScreenState extends State<ImportScreen> {
+  final _logger = Logger('ImportScreen');
+
+  final GlobalKey<SpawnOrionTextFieldState> _jobNameKey =
+      GlobalKey<SpawnOrionTextFieldState>();
+
+  String? _selectedResinKey;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  String _defaultJobName() {
+    return path.basenameWithoutExtension(widget.fileName);
+  }
+
+  bool _isStlFile() {
+    return widget.fileName.toLowerCase().endsWith('.stl');
+  }
+
+  Future<void> _deleteLocalFile() async {
+    try {
+      final file = File(widget.filePath);
+      if (await file.exists()) {
+        await file.delete();
+      }
+      if (mounted) {
+        Navigator.pop(context, true);
+      }
+    } catch (e, st) {
+      _logger.warning('Failed to delete local file', e, st);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to delete file')),
+        );
+      }
+    }
+  }
+
+  Future<void> _importFile() async {
+    final jobName = _jobNameKey.currentState?.getCurrentText().trim() ?? _defaultJobName();
+    
+    if (jobName.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter a job name')),
+      );
+      return;
+    }
+
+    if (_selectedResinKey == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please select a material profile')),
+      );
+      return;
+    }
+
+    // Create notifiers for progress overlay
+    final progressNotifier = ValueNotifier<double>(0.0);
+    final messageNotifier = ValueNotifier<String>('Preparing import...');
+    final titleNotifier = ValueNotifier<String>('IMPORTING FILE');
+    final iconNotifier = ValueNotifier<IconData>(PhosphorIconsFill.upload);
+
+    // Show import progress overlay
+    if (mounted) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => ImportProgressOverlay(
+            progress: progressNotifier,
+            message: messageNotifier,
+            title: titleNotifier,
+            iconListenable: iconNotifier,
+          ),
+          fullscreenDialog: true,
+        ),
+      );
+    }
+
+    try {
+      messageNotifier.value = 'Uploading file...';
+      progressNotifier.value = 0.05;
+      
+      final resinsProvider = Provider.of<ResinsProvider>(context, listen: false);
+      final resins = resinsProvider.userResins;
+      final selectedResin = resins.firstWhere(
+        (r) => (r.path ?? r.name) == _selectedResinKey,
+        orElse: () => resins.first,
+      );
+
+      // Extract profile ID from the resin profile
+      final profileId = selectedResin.path ?? selectedResin.name;
+
+          // Create a backend service instance to import the file
+          final backendService = BackendService();
+
+          // Capture current file list so we can detect the newly imported file
+          final filesProvider = FilesProvider(client: backendService);
+          final existingItems =
+            await filesProvider.listItemsAsOrionApiItems('Local', '');
+          final existingKeys = existingItems
+            .whereType<OrionApiFile>()
+            .map((f) => _fileKey(f))
+            .toSet();
+      
+      final importRequest = NanoImportRequest(
+        usbFilePath: widget.filePath,
+        jobName: jobName,
+        profileId: profileId,
+      );
+
+      final plateId = await backendService.importFile(importRequest);
+      
+      if (mounted) {
+        messageNotifier.value = 'Processing file metadata...';
+        
+        // Poll for the newly imported file to appear with valid metadata
+        bool fileReady = false;
+        int pollAttempts = 0;
+        const maxAttempts = 50; // 50 attempts * 300ms = 15 seconds max (NanoDLP needs time to process)
+        
+        while (!fileReady && pollAttempts < maxAttempts && mounted) {
+          await Future.delayed(const Duration(milliseconds: 300));
+          pollAttempts++;
+          
+          try {
+            backendService.invalidateFilesCache();
+            final items = await filesProvider.listItemsAsOrionApiItems('Local', '');
+            
+            // Find the imported file: prefer plate ID when available, otherwise diff or name match
+            OrionApiFile? newFile;
+            if (plateId != null) {
+              newFile = items.whereType<OrionApiFile>().firstWhere(
+                    (item) => item.file == plateId.toString(),
+                    orElse: () => throw Exception('File not found'),
+                  );
+            } else {
+              // Try diff against the pre-import snapshot
+              final newCandidates = items
+                  .whereType<OrionApiFile>()
+                  .where((item) => !existingKeys.contains(_fileKey(item)))
+                  .toList();
+
+              // Prefer a candidate that matches the requested job name
+              if (newCandidates.isNotEmpty) {
+                newFile = newCandidates.firstWhere(
+                  (item) => _matchesJobName(item, jobName),
+                  orElse: () => newCandidates.first,
+                );
+              }
+
+              // If no diff was detected, fall back to a name match in the full list
+              newFile ??= items.whereType<OrionApiFile>().firstWhere(
+                    (item) => _matchesJobName(item, jobName),
+                    orElse: () => throw Exception('File not found'),
+                  );
+            }
+            
+            // Check if metadata is populated (NanoDLP may take time to fill fields)
+            final metaPath = _metadataPathForFile(newFile);
+            final meta = await filesProvider.fetchFileMetadata('Local', metaPath);
+            final metaReady = _isMetadataReady(meta);
+            final listReady = (newFile.layerHeight != null && newFile.layerHeight! > 0) ||
+                (newFile.layerCount != null && newFile.layerCount! > 0) ||
+                (newFile.printTime != null && newFile.printTime! > 0);
+
+            if (metaReady || listReady) {
+              fileReady = true;
+              if (_isStlFile()) {
+                progressNotifier.value = 0.5;
+                await _pollSlicerProgress(
+                  progressNotifier,
+                  messageNotifier,
+                  baseProgress: 0.5,
+                  span: 0.5,
+                  titleNotifier: titleNotifier,
+                  iconNotifier: iconNotifier,
+                );
+              } else {
+                progressNotifier.value = 1.0;
+                messageNotifier.value = 'Import complete!';
+              }
+              
+              // Wait a moment for the UI to show completion, then navigate
+              await Future.delayed(const Duration(milliseconds: 800));
+              
+              if (mounted) {
+                // Close overlay and navigate to DetailsScreen
+                Navigator.of(context).pop(); // Close overlay
+                
+                final result = await Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => DetailScreen(
+                      fileName: newFile!.name,
+                      fileSubdirectory: '',
+                      fileLocation: 'Local',
+                      returnToLocalOnPop: true,
+                    ),
+                  ),
+                );
+                if (mounted) {
+                  Navigator.of(context).pop(
+                    result ?? <String, dynamic>{'switchToLocal': true},
+                  );
+                }
+              }
+            } else {
+              // File found but metadata not ready yet, update progress
+                final progress =
+                  (pollAttempts / maxAttempts).clamp(0.0, 1.0) * 0.5;
+                progressNotifier.value = progress;
+            }
+          } catch (e) {
+            if (pollAttempts >= maxAttempts && mounted) {
+              // Timeout waiting for file/metadata
+              messageNotifier.value = 'Import complete (metadata pending)';
+              progressNotifier.value = 1.0;
+              
+              await Future.delayed(const Duration(milliseconds: 800));
+              
+              if (mounted) {
+                Navigator.of(context).pop(); // Close overlay
+                Navigator.of(context).pop(true); // Go back to files screen
+              }
+            }
+          }
+        }
+      }
+    } catch (e, st) {
+      _logger.severe('Failed to import file', e, st);
+      if (mounted) {
+        messageNotifier.value = 'Import failed!';
+        progressNotifier.value = 0.0;
+        
+        await Future.delayed(const Duration(milliseconds: 1000));
+        
+        Navigator.of(context).pop(); // Close overlay
+        
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to import file: $e')),
+        );
+      }
+    }
+  }
+
+  String _fileKey(OrionApiFile file) {
+    final pathPart = file.path.trim().toLowerCase();
+    final namePart = file.name.trim().toLowerCase();
+    return '$pathPart|$namePart';
+  }
+
+  bool _matchesJobName(OrionApiFile file, String jobName) {
+    final normalizedJob = jobName.trim().toLowerCase();
+    if (normalizedJob.isEmpty) return false;
+    final name = file.name.trim().toLowerCase();
+    final path = file.path.trim().toLowerCase();
+    return name.contains(normalizedJob) || path.contains(normalizedJob);
+  }
+
+  String _metadataPathForFile(OrionApiFile file) {
+    final pathValue = file.path.trim();
+    if (pathValue.isNotEmpty) return pathValue;
+    return file.name.trim();
+  }
+
+  bool _isMetadataReady(FileMetadata? meta) {
+    if (meta == null) return false;
+    if (meta.layerHeight != null && meta.layerHeight! > 0) return true;
+    if (meta.printTime != null && meta.printTime! > 0) return true;
+    if (meta.usedMaterial != null && meta.usedMaterial! > 0) return true;
+    if (meta.fileData.lastModified > 0) return true;
+    return false;
+  }
+
+  Future<void> _pollSlicerProgress(
+    ValueNotifier<double> progressNotifier,
+    ValueNotifier<String> messageNotifier,
+    {double baseProgress = 0.0,
+    double span = 1.0,
+    ValueNotifier<String>? titleNotifier,
+    ValueNotifier<IconData>? iconNotifier}
+  ) async {
+    messageNotifier.value = 'Ever tried DragonFruit? It\'s delicious!';
+
+    final startTime = DateTime.now();
+    const timeout = Duration(minutes: 15);
+    bool sawReset = false;
+    bool sawProgress = false;
+
+    while (mounted) {
+      final progress = await BackendService().getSlicerProgress();
+
+      if (progress == null) {
+        if (!sawProgress) {
+          messageNotifier.value = 'Waiting for slicer to start...';
+        }
+        progressNotifier.value = baseProgress;
+      } else {
+        sawProgress = true;
+        final raw = progress < 0 ? 0.0 : progress;
+        final normalizedValue = raw > 1.0 ? (raw / 100.0) : raw;
+        final clamped = normalizedValue.clamp(0.0, 1.0);
+
+        // Ignore stale 100% from a previous slice until we observe a reset.
+        if (!sawReset && clamped >= 0.99) {
+          messageNotifier.value = 'Waiting for slicer to start...';
+          progressNotifier.value = baseProgress;
+        } else {
+          if (clamped < 0.95) {
+            sawReset = true;
+          }
+          if (sawReset) {
+            titleNotifier?.value = 'SLICING JOB';
+            iconNotifier?.value = PhosphorIcons.knife();
+          }
+          messageNotifier.value = 'Ever tried DragonFruit? It\'s delicious!';
+          final normalized = clamped.clamp(0.0, 0.99);
+          progressNotifier.value = baseProgress + (normalized * span);
+        }
+
+        if (sawReset && clamped >= 0.99) {
+          messageNotifier.value = 'File sliced successfully!';
+          progressNotifier.value = baseProgress + span;
+          break;
+        }
+      }
+
+      if (DateTime.now().difference(startTime) > timeout) {
+        messageNotifier.value = 'Slicing timed out';
+        break;
+      }
+
+      await Future.delayed(const Duration(seconds: 1));
+    }
+  }
+
+  Future<void> _sliceFile() async {
+    await _importFile();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassApp(
+      child: Scaffold(
+        appBar: OrionAppBar(
+          actions: const [SystemStatusWidget()],
+          toolbarHeight: Theme.of(context).appBarTheme.toolbarHeight,
+          title: const Text('Back'),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              Expanded(
+                flex: 1,
+                child: _buildJobNameField(context),
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                flex: 1,
+                child: _buildMaterialSelector(context),
+              ),
+              const SizedBox(height: 24),
+              _buildActionButtons(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildJobNameField(BuildContext context) {
+    return GlassCard(
+      outlined: true,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 16),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: SpawnOrionTextField(
+                  key: _jobNameKey,
+                  keyboardHint: 'Job Name',
+                  locale: Localizations.localeOf(context).toString(),
+                  presetText: _defaultJobName(),
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: OrionKbExpander(textFieldKey: _jobNameKey),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMaterialSelector(BuildContext context) {
+    final provider = Provider.of<ResinsProvider>(context);
+
+    if (provider.isLoading) {
+      return GlassCard(
+        outlined: true,
+        child: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (provider.error != null) {
+      return GlassCard(
+        outlined: true,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Failed to load material profiles'),
+            const SizedBox(height: 16),
+            GlassButton(
+              onPressed: provider.refresh,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final resins = provider.userResins;
+    if (resins.isEmpty) {
+      return GlassCard(
+        outlined: true,
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('Material Profile', style: TextStyle(fontSize: 16)),
+              const SizedBox(height: 8),
+              const Text('No material profiles found', style: TextStyle(fontSize: 14, color: Colors.grey)),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Find selected resin object for display
+    ResinProfile? selectedResin;
+    if (_selectedResinKey != null) {
+      selectedResin = resins.firstWhere(
+        (r) => (r.path ?? r.name) == _selectedResinKey,
+        orElse: () => resins.first,
+      );
+    }
+    // Default to active resin if available
+    if (selectedResin == null) {
+      selectedResin = resins.firstWhere(
+        (r) => (r.path ?? r.name) == provider.activeResinKey,
+        orElse: () => resins.first,
+      );
+      _selectedResinKey = selectedResin.path ?? selectedResin.name;
+    }
+
+    return GlassCard(
+      outlined: true,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14),
+        onTap: () => _selectResinProfile(resins),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+              child: Text(
+                'Material Profile',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            AutoSizeText(
+                              selectedResin.name,
+                              maxLines: 2,
+                              minFontSize: 14,
+                              style: const TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.w500,
+                              ),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ],
+                        ),
+                      ),
+                      Icon(Icons.chevron_right, color: Colors.grey.shade400, size: 24),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _selectResinProfile(List<ResinProfile> resins) async {
+    if (resins.isEmpty) {
+      return;
+    }
+
+    await showDialog(
+      context: context,
+      builder: (context) => GlassDialog(
+        padding: EdgeInsets.zero,
+        child: SizedBox(
+          width: MediaQuery.of(context).size.width * 0.9,
+          height: MediaQuery.of(context).size.height * 0.8,
+          child: Column(
+            children: [
+              // Header Section
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      color: Theme.of(context).dividerColor.withValues(alpha: 0.3),
+                      width: 1,
+                    ),
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(Icons.water_drop, size: 24),
+                    const SizedBox(width: 12),
+                    const Expanded(
+                      child: Text(
+                        'Select Resin Profile',
+                        style: TextStyle(
+                          fontSize: 22,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    if (_selectedResinKey != null) ...[
+                      Container(
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                        decoration: BoxDecoration(
+                          color:
+                              Theme.of(context).colorScheme.primaryContainer,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          resins
+                              .firstWhere(
+                                (r) => (r.path ?? r.name) == _selectedResinKey,
+                                orElse: () => resins.first,
+                              )
+                              .name,
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.primary,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w500,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                    ],
+                    IconButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      icon: const Icon(Icons.close, size: 20),
+                      padding: const EdgeInsets.all(4),
+                      constraints:
+                          const BoxConstraints(minWidth: 32, minHeight: 32),
+                      tooltip: 'Close',
+                    ),
+                  ],
+                ),
+              ),
+
+              // Content Section
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: ListView.separated(
+                    itemCount: resins.length,
+                    separatorBuilder: (ctx, i) => const SizedBox(height: 12),
+                    itemBuilder: (context, index) {
+                      final resin = resins[index];
+                      final resinKey = resin.path ?? resin.name;
+                      final isSelected = _selectedResinKey == resinKey;
+                      final meta = resin.meta;
+                      final parts = <String>[];
+                      if (meta['viscosity'] != null) {
+                        parts.add('Viscosity: ${meta['viscosity']}');
+                      }
+                      if (meta['exposure'] != null) {
+                        parts.add('Exposure: ${meta['exposure']}');
+                      }
+
+                      return GlassCard(
+                        elevation: isSelected ? 2.0 : 1.0,
+                        outlined: true,
+                        color: isSelected
+                            ? Theme.of(context)
+                                .colorScheme
+                                .primaryContainer
+                                .withValues(alpha: 0.3)
+                            : null,
+                        child: InkWell(
+                          onTap: () {
+                            setState(() {
+                              _selectedResinKey = resinKey;
+                            });
+                            Navigator.of(context).pop();
+                          },
+                          borderRadius: BorderRadius.circular(16),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 20, vertical: 20),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Text(
+                                        resin.name,
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                          fontWeight: FontWeight.w500,
+                                          color: isSelected
+                                              ? Theme.of(context)
+                                                  .colorScheme
+                                                  .primary
+                                              : null,
+                                        ),
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                      if (parts.isNotEmpty) ...[
+                                        const SizedBox(height: 6),
+                                        Text(
+                                          parts.join(' • '),
+                                          style: TextStyle(
+                                            fontSize: 14,
+                                            color: Theme.of(context)
+                                                .textTheme
+                                                .bodySmall
+                                                ?.color,
+                                          ),
+                                        ),
+                                      ],
+                                    ],
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                Container(
+                                  width: 28,
+                                  height: 28,
+                                  decoration: BoxDecoration(
+                                    color: isSelected
+                                        ? Theme.of(context).colorScheme.primary
+                                        : Colors.transparent,
+                                    border: isSelected
+                                        ? null
+                                        : Border.all(
+                                            color:
+                                                Theme.of(context).dividerColor,
+                                            width: 2),
+                                    borderRadius: BorderRadius.circular(14),
+                                  ),
+                                  child: isSelected
+                                      ? const Icon(Icons.check,
+                                          color: Colors.white, size: 18)
+                                      : null,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActionButtons(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          flex: 1,
+          child: GlassButton(
+            tint: GlassButtonTint.negative,
+            wantIcon: false,
+            onPressed: () {
+              _deleteLocalFile();
+            },
+            style: ElevatedButton.styleFrom(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(15),
+              ),
+              minimumSize: const Size(0, 65),
+            ),
+            child: const Text(
+              'Delete',
+              style: TextStyle(fontSize: 20),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        const SizedBox(width: 20),
+        Expanded(
+          flex: 1,
+          child: GlassButton(
+            tint: GlassButtonTint.positive,
+            onPressed: _isStlFile() ? _sliceFile : _importFile,
+            style: ElevatedButton.styleFrom(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(15),
+              ),
+              minimumSize: const Size(0, 65),
+            ),
+            child: Text(
+              _isStlFile() ? 'Slice' : 'Import',
+              style: const TextStyle(fontSize: 22),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/glasser/src/widgets/glass_floating_action_button.dart
+++ b/lib/glasser/src/widgets/glass_floating_action_button.dart
@@ -119,9 +119,8 @@ class GlassFloatingActionButton extends StatelessWidget {
 
     if (!themeProvider.isGlassTheme) {
       final cs = Theme.of(context).colorScheme;
-      final bg = tintPalette != null
-          ? tintPalette.color.withValues(alpha: 0.10)
-          : cs.secondaryContainer;
+      final bg =
+          tintPalette != null ? tintPalette.color : cs.secondaryContainer;
       final fg = tintPalette != null
           ? tintPalette.materialForeground
           : cs.onSecondaryContainer;
@@ -316,6 +315,7 @@ class GlassFloatingActionButton extends StatelessWidget {
       );
     } else {
       final borderRadius = BorderRadius.circular(glassCornerRadius);
+      final forceBlur = doForceBlur;
       final shadow = GlassPlatformConfig.interactiveShadow(
         enabled: onPressed != null,
         blurRadius: 24,
@@ -352,7 +352,7 @@ class GlassFloatingActionButton extends StatelessWidget {
               opacity: fillOpacity,
               color: blendedFillColor,
               floatingSurface: true,
-              interactiveSurface: true,
+              interactiveSurface: forceBlur ? false : true,
               borderWidth: 1.6,
               emphasizeBorder: true,
               borderColor: borderColor,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,6 +47,7 @@ import 'package:orion/materials/materials_screen.dart';
 import 'package:orion/materials/calibration_context_provider.dart';
 import 'package:orion/backend_service/providers/status_provider.dart';
 import 'package:orion/backend_service/providers/files_provider.dart';
+import 'package:orion/backend_service/providers/local_files_provider.dart';
 import 'package:orion/backend_service/providers/config_provider.dart';
 import 'package:orion/backend_service/providers/print_provider.dart';
 import 'package:orion/backend_service/providers/notification_provider.dart';
@@ -230,6 +231,10 @@ class OrionRoot extends StatelessWidget {
         ),
         ChangeNotifierProvider(
           create: (_) => FilesProvider(),
+          lazy: true,
+        ),
+        ChangeNotifierProvider(
+          create: (_) => LocalFilesProvider(),
           lazy: true,
         ),
         ChangeNotifierProvider(

--- a/lib/themes/themes.dart
+++ b/lib/themes/themes.dart
@@ -26,7 +26,7 @@ String get _primaryFontFamily {
   if (Platform.isLinux) {
     return 'AtkinsonHyperlegible';
   }
-  return 'AtkinsonHyperlegibleNext';
+  return 'AtkinsonHyperlegible';
 }
 
 ThemeData createLightTheme(Color seedColor) {

--- a/lib/util/orion_api_filesystem/orion_api_file.dart
+++ b/lib/util/orion_api_filesystem/orion_api_file.dart
@@ -32,6 +32,7 @@ class OrionApiFile implements OrionApiItem {
   final double? printTime;
   final double? layerHeight;
   final int? layerCount;
+  final int? plateId;
 
   OrionApiFile({
     this.file,
@@ -44,6 +45,7 @@ class OrionApiFile implements OrionApiItem {
     this.printTime,
     this.layerHeight,
     this.layerCount,
+    this.plateId,
   });
 
   factory OrionApiFile.fromJson(Map<String, dynamic> json) {
@@ -60,6 +62,7 @@ class OrionApiFile implements OrionApiItem {
       printTime: json['print_time'] ?? 0.0,
       layerHeight: json['layer_height'] ?? 0.0,
       layerCount: json['layer_count'] ?? 0,
+      plateId: json['plate_id'] ?? json['PlateID'],
     );
   }
 }


### PR DESCRIPTION
Unlike Odyssey, NanoDLP does not allow to print files stored on a USB drive directly, but instead requires importing them.

For this, `LocalFilesProvider` has been implemented, allowing us browse local files instead of the API, using `GridFilesScreen`

Two methods to import files have been added for NanoDLP, you can:

- Import a NanoDLP, while choosing an on-board resin profile to associated the print job with, 
OR
- Import and slice a pre-supported STL file, while choosing an on-board resin profile.

Other small (QoL) fixes have also been included while refactoring some code associated with print files.