### PR TITLE
fix: Performance Tweaks

### DIFF
--- a/lib/files/grid_files_screen.dart
+++ b/lib/files/grid_files_screen.dart
@@ -165,7 +165,21 @@ class GridFilesScreenState extends State<GridFilesScreen> {
             _defaultDirectory = provider.baseDirectory;
             _directory = _defaultDirectory;
           }
-          await _prewarmThumbnailCache(provider, 'Usb');
+
+          // Preload processed thumbnails from disk so the grid shows
+          // images instantly on cold start without re-processing.
+          final processedMap =
+              await ThumbnailCache.instance.preloadProcessedThumbnails('Usb');
+          for (final entry in processedMap.entries) {
+            _processedThumbnailCache[entry.key] = entry.value;
+          }
+
+          // Show grid immediately — thumbnails fill in as they load.
+          if (mounted) setState(() => _isLoading = false);
+
+          // Background prewarm: enqueue missing thumbnails through the
+          // concurrency-controlled queue so we don't saturate the device.
+          _prewarmMissingThumbnails(provider, 'Usb');
         } else {
           // Load from FilesProvider (API)
           final provider = Provider.of<FilesProvider>(context, listen: false);
@@ -189,9 +203,24 @@ class GridFilesScreenState extends State<GridFilesScreen> {
             _defaultDirectory = homeDir;
             _directory = _defaultDirectory;
           }
-          await _prewarmThumbnailCache(provider, _isUSB ? 'Usb' : 'Local');
+
+          final location = _isUSB ? 'Usb' : 'Local';
+
+          // Preload processed thumbnails from disk so the grid shows
+          // images instantly on cold start without re-processing.
+          final processedMap =
+              await ThumbnailCache.instance.preloadProcessedThumbnails(location);
+          for (final entry in processedMap.entries) {
+            _processedThumbnailCache[entry.key] = entry.value;
+          }
+
+          // Show grid immediately — thumbnails fill in as they load.
+          if (mounted) setState(() => _isLoading = false);
+
+          // Background prewarm: enqueue missing thumbnails through the
+          // concurrency-controlled queue so we don't saturate the device.
+          _prewarmMissingThumbnails(provider, location);
         }
-        if (mounted) setState(() => _isLoading = false);
       }
     });
   }
@@ -300,6 +329,9 @@ class GridFilesScreenState extends State<GridFilesScreen> {
           );
           if (bytes != null && bytes.isNotEmpty) {
             _touchProcessedCache(key, bytes);
+            // Persist processed bytes to disk so the thumbnail is
+            // instantly available after a reboot without re-processing.
+            ThumbnailCache.instance.storeProcessedBytes(key, bytes);
           }
           if (!completer.isCompleted) completer.complete(bytes);
         } catch (e, st) {
@@ -420,19 +452,16 @@ class GridFilesScreenState extends State<GridFilesScreen> {
     _processedThumbnailCache.removeWhere((key, _) => !allowed.contains(key));
   }
 
-  /// Pre-populate [_processedThumbnailCacheGlobal] from disk for all files in
-  /// the current view so the grid can show images without per-item spinners.
-  /// STL files are skipped (they require runtime rendering, not a simple disk
-  /// read).  Items already in the processed cache are also skipped.
-  /// A 2-second wall-clock timeout prevents this from blocking the UI
-  /// indefinitely when many files are uncached.
-  Future<void> _prewarmThumbnailCache(dynamic provider, String location) async {
+  /// Enqueue thumbnails that are missing from the processed cache through the
+  /// normal concurrency-controlled queue. This runs in the background after
+  /// the grid is already visible so the UI stays responsive.
+  ///
+  /// Files already present in [_processedThumbnailCache] are skipped, and
+  /// STL files are skipped (they require runtime rendering).
+  void _prewarmMissingThumbnails(dynamic provider, String location) {
     final List<OrionApiItem> items = List<OrionApiItem>.from(provider.items);
     final files = items.whereType<OrionApiFile>().toList();
     if (files.isEmpty) return;
-
-    const maxParallel = 4;
-    final tasks = <Future<void> Function()>[];
 
     for (final file in files) {
       final fileName = path.basename(file.path);
@@ -440,45 +469,22 @@ class GridFilesScreenState extends State<GridFilesScreen> {
       // STL thumbnails are rendered at runtime, not stored as simple image data.
       if (lower.endsWith('.stl')) continue;
 
+      final key = _thumbCacheKey(location, file, 'Small');
+      if (_processedThumbnailCache.containsKey(key)) continue;
+
       final subdirectory = provider is LocalFilesProvider
           ? _resolveLocalSubdirectoryForFile(file, provider)
           : _resolveSubdirectoryForFile(file);
 
-      final key = _thumbCacheKey(location, file, 'Small');
-      if (_processedThumbnailCache.containsKey(key)) continue;
-
-      tasks.add(() async {
-        try {
-          final rawBytes = await ThumbnailCache.instance.getThumbnail(
-            location: location,
-            subdirectory: subdirectory,
-            fileName: fileName,
-            file: file,
-            size: 'Small',
-          );
-          final bytes =
-              await _postProcessGridThumbnail(rawBytes, size: 'Small');
-          if (bytes != null && bytes.isNotEmpty) {
-            _touchProcessedCache(key, bytes);
-          }
-        } catch (_) {}
-      });
+      // Route through the normal queue so concurrency limits are respected.
+      _queuedGetThumbnail(
+        location: location,
+        subdirectory: subdirectory,
+        fileName: fileName,
+        file: file,
+        size: 'Small',
+      );
     }
-
-    if (tasks.isEmpty) return;
-
-    // Run in batches to avoid saturating I/O; cap total time at 2 s.
-    Future<void> runBatched() async {
-      for (int i = 0; i < tasks.length; i += maxParallel) {
-        final batch = tasks.skip(i).take(maxParallel).map((t) => t()).toList();
-        await Future.wait(batch);
-      }
-    }
-
-    await Future.any([
-      runBatched(),
-      Future.delayed(const Duration(seconds: 2)),
-    ]);
   }
 
   void _processThumbnailQueue() {
@@ -603,7 +609,15 @@ class GridFilesScreenState extends State<GridFilesScreen> {
         final currentPaths = currentFiles.map((f) => f.path).toList();
         ThumbnailCache.instance.validateAndCleanup('Usb', currentPaths);
         _pruneThumbnailFutureCache('Usb', currentFiles);
-        await _prewarmThumbnailCache(provider, 'Usb');
+
+        // Preload processed thumbnails from disk, then show grid immediately.
+        final processedMap =
+            await ThumbnailCache.instance.preloadProcessedThumbnails('Usb');
+        for (final entry in processedMap.entries) {
+          _processedThumbnailCache[entry.key] = entry.value;
+        }
+        if (mounted) setState(() => _isLoading = false);
+        _prewarmMissingThumbnails(provider, 'Usb');
       } else {
         final provider = Provider.of<FilesProvider>(context, listen: false);
         await provider.loadItems(_isUSB ? 'Usb' : 'Local', _subdirectory);
@@ -615,11 +629,17 @@ class GridFilesScreenState extends State<GridFilesScreen> {
         ThumbnailCache.instance
             .validateAndCleanup(_isUSB ? 'Usb' : 'Local', currentPaths);
         _pruneThumbnailFutureCache(_isUSB ? 'Usb' : 'Local', currentFiles);
-        await _prewarmThumbnailCache(provider, _isUSB ? 'Usb' : 'Local');
+
+        final location = _isUSB ? 'Usb' : 'Local';
+        // Preload processed thumbnails from disk, then show grid immediately.
+        final processedMap =
+            await ThumbnailCache.instance.preloadProcessedThumbnails(location);
+        for (final entry in processedMap.entries) {
+          _processedThumbnailCache[entry.key] = entry.value;
+        }
+        if (mounted) setState(() => _isLoading = false);
+        _prewarmMissingThumbnails(provider, location);
       }
-      setState(() {
-        _isLoading = false;
-      });
     } catch (e) {
       if (!mounted) return;
       setState(() {

--- a/lib/util/thumbnail_cache.dart
+++ b/lib/util/thumbnail_cache.dart
@@ -270,6 +270,64 @@ class ThumbnailCache {
     return dir.path;
   }
 
+  /// Persist a post-processed (trimmed/cropped) thumbnail to disk so it
+  /// survives reboots without needing to re-run expensive post-processing.
+  /// The [key] should be the same cache key used for the raw thumbnail,
+  /// and the stored bytes are the already-processed result.
+  Future<void> storeProcessedBytes(String key, Uint8List bytes) async {
+    try {
+      await _writeToDiskSafe('$key|p', bytes);
+    } catch (_) {
+      // best-effort; ignore disk write failures
+    }
+  }
+
+  /// Bulk-load all processed thumbnails for a given [location] from disk.
+  /// Returns a map of original cache keys to their processed bytes.
+  /// Call this at startup to repopulate the in-memory processed cache so
+  /// the grid can display thumbnails instantly without re-processing.
+  Future<Map<String, Uint8List>> preloadProcessedThumbnails(
+      String location) async {
+    final result = <String, Uint8List>{};
+    try {
+      final dir = await _ensureDiskCacheDir();
+      final prefix = Uri.encodeComponent('$location|');
+      const suffix = '|p';
+      final entities = await dir.list().toList();
+      for (final entity in entities) {
+        if (entity is! File) continue;
+        final name = p.basename(entity.path);
+        if (!name.startsWith(prefix) || !name.endsWith(suffix)) continue;
+        final decoded = Uri.decodeComponent(name);
+        final originalKey =
+            decoded.substring(0, decoded.length - suffix.length);
+        // Honour disk TTL for processed entries too.
+        if (_diskEntryTtl != null) {
+          try {
+            final mtime = entity.lastModifiedSync();
+            if (DateTime.now().difference(mtime) > _diskEntryTtl!) {
+              try {
+                await entity.delete();
+              } catch (_) {}
+              continue;
+            }
+          } catch (_) {
+            continue;
+          }
+        }
+        try {
+          final bytes = await entity.readAsBytes();
+          result[originalKey] = bytes;
+        } catch (_) {
+          // skip unreadable files
+        }
+      }
+    } catch (_) {
+      // best-effort; ignore directory listing errors
+    }
+    return result;
+  }
+
   void clear() {
     _cache.clear();
     _inFlight.clear();

--- a/lib/util/thumbnail_cache.dart
+++ b/lib/util/thumbnail_cache.dart
@@ -291,16 +291,19 @@ class ThumbnailCache {
     final result = <String, Uint8List>{};
     try {
       final dir = await _ensureDiskCacheDir();
-      final prefix = Uri.encodeComponent('$location|');
-      const suffix = '|p';
+      final rawPrefix = '$location|';
+      const rawSuffix = '|p';
       final entities = await dir.list().toList();
       for (final entity in entities) {
         if (entity is! File) continue;
-        final name = p.basename(entity.path);
-        if (!name.startsWith(prefix) || !name.endsWith(suffix)) continue;
-        final decoded = Uri.decodeComponent(name);
+        // Disk filenames are URI-encoded — decode before comparing so
+        // literal '|' in the key matches encoded '%7C' on disk.
+        final decoded = Uri.decodeComponent(p.basename(entity.path));
+        if (!decoded.startsWith(rawPrefix) || !decoded.endsWith(rawSuffix)) {
+          continue;
+        }
         final originalKey =
-            decoded.substring(0, decoded.length - suffix.length);
+            decoded.substring(0, decoded.length - rawSuffix.length);
         // Honour disk TTL for processed entries too.
         if (_diskEntryTtl != null) {
           try {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "91.0.0"
   about:
     dependency: "direct main"
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "8.4.1"
   animations:
     dependency: "direct main"
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -237,10 +237,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   english_words:
     dependency: "direct main"
     description:
@@ -493,14 +493,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.27"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
@@ -577,26 +569,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -990,26 +982,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.28.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.14"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
This pull request significantly improves thumbnail loading performance and user experience in the file grid by introducing disk persistence for processed thumbnails and optimizing the cache preloading and warming logic. The main changes ensure that thumbnails appear instantly on cold start and that expensive post-processing is avoided when possible.

**Thumbnail cache improvements:**

* Added `storeProcessedBytes` and `preloadProcessedThumbnails` methods to `ThumbnailCache` to persist and bulk-load post-processed thumbnails from disk, allowing instant thumbnail display after app restarts and avoiding redundant processing.
* Updated the thumbnail generation flow in `GridFilesScreenState` to store processed thumbnails to disk after processing, ensuring future loads are faster.

**Grid loading and UI responsiveness:**

* Refactored the grid loading logic to preload all available processed thumbnails from disk before rendering the grid, so images appear instantly without waiting for processing. The grid is shown immediately, and missing thumbnails are fetched in the background. [[1]](diffhunk://#diff-b15b663f36816ffc3944cb1580eb1856ae90a21391b64b75a1c76b1af4457d82L168-R182) [[2]](diffhunk://#diff-b15b663f36816ffc3944cb1580eb1856ae90a21391b64b75a1c76b1af4457d82L192-R223) [[3]](diffhunk://#diff-b15b663f36816ffc3944cb1580eb1856ae90a21391b64b75a1c76b1af4457d82L606-R620) [[4]](diffhunk://#diff-b15b663f36816ffc3944cb1580eb1856ae90a21391b64b75a1c76b1af4457d82L618-L622)
* Replaced the old `_prewarmThumbnailCache` method with a new `_prewarmMissingThumbnails` method that enqueues only missing thumbnails for background processing, further improving UI responsiveness and reducing unnecessary work.